### PR TITLE
Use protocol relative URLs

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,8 +7,8 @@
     <link rel="stylesheet" href="stylesheet.css">
 </head>
 <body>
-  <script src="http://d3js.org/d3.v3.min.js" charset="utf-8"></script>
-  <script src="https://code.jquery.com/jquery-1.11.0.min.js"></script>
+  <script src="//d3js.org/d3.v3.min.js" charset="utf-8"></script>
+  <script src="//code.jquery.com/jquery-1.11.0.min.js"></script>
   <script src="js/colors.js"></script>
   <header>
     <h1>Bay Area Bike Share Data Challenge</h1>
@@ -18,7 +18,7 @@
   <div class="wrapper">
     
     <h2 class="analysis">What is the Bay Area Bike Share?</h2>
-    <p class="analysis">The <a href="http://bayareabikeshare.com/">Bay Area Bike Share</a> system allows users to rent bicycles for short journeys between stations throughout the city.  Users can be annual members or short term (1 or 3 days).  The system is completely automated for users. </p>
+    <p class="analysis">The <a href="//bayareabikeshare.com/">Bay Area Bike Share</a> system allows users to rent bicycles for short journeys between stations throughout the city.  Users can be annual members or short term (1 or 3 days).  The system is completely automated for users. </p>
     <p class="analysis">There are <strong>69</strong> stations across <strong>5</strong> cities in the Bike Share system, with an average of <strong>17</strong> docks per station.</p>
     <div id="pies" class="chart"></div>
     <p class="analysis">About <strong>50%</strong> of the stations and docks are located in San Francisco, but it makes up <strong>90%</strong> of the system use.</p>
@@ -278,7 +278,7 @@
   
   <footer>
     I did not perform any actual statistical tests; with figuring out D3, I didn't have time to re-learn T-tests and whatnot.  I would maybe be interested in doing that to see if my conjectures have any basis in math. <br />
-    Made with <a href="http://www.d3js.org">D3</a> and <a href="http://www.openoffice.org/">Open Office</a>.  Data from the <a href="http://bayareabikeshare.com/datachallenge">Bay Area Bike Share Data Challenge</a>.
+    Made with <a href="//www.d3js.org">D3</a> and <a href="//www.openoffice.org/">Open Office</a>.  Data from the <a href="//bayareabikeshare.com/datachallenge">Bay Area Bike Share Data Challenge</a>.
   </footer>
   
   <script src="js/main.js"></script>


### PR DESCRIPTION
When trying to access thfield.github.io/babs/index.html through "https" (https://thfield.github.io/babs/index.html) d3 charts are not loaded. 
These changes will help with other people trying to access your page through a secure http request. 
Thanks in advance.